### PR TITLE
Implement All Desktop Audio

### DIFF
--- a/native/connector/pipewire-screen-audio-connector.sh
+++ b/native/connector/pipewire-screen-audio-connector.sh
@@ -28,7 +28,7 @@ function toMessage () {
 }
 
 function GetNodes () {
-  local nodes=`pactl -f json list | jq '.sink_inputs' | jq -c '[ .[] | select(.properties["media.class"] == "Stream/Output/Audio") ]'`
+  local nodes=`pactl -f json list | jq '.sink_inputs' | jq -c '[{"properties": {"media.name": "[All Desktop Audio]", "application.name": "", "object.serial": -1}}] + [ .[] | select(.properties["media.class"] == "Stream/Output/Audio") ]'`
   toMessage "$nodes"
   exit
 }

--- a/native/pipewire-screenaudio/main.cpp
+++ b/native/pipewire-screenaudio/main.cpp
@@ -9,7 +9,7 @@ std::optional<pipewire::port> virt_fl, virt_fr;
 std::map<std::uint32_t, pipewire::node> nodes;
 std::map<std::uint32_t, pipewire::link> links;
 
-std::vector<std::string> EXCLUDE_TARGETS{"Firefox"};
+std::vector<std::string> EXCLUDE_TARGETS{"AudioCallbackDriver"};
 
 bool isExcluded(const std::string &target) {
   auto it = std::find(EXCLUDE_TARGETS.begin(), EXCLUDE_TARGETS.end(), target);
@@ -46,9 +46,9 @@ void link(const std::string &target, pipewire::core &core)
         }
 
         auto code = parent.info().props["object.serial"];
-        auto name = parent.info().props["node.name"];
+        auto media_name = parent.info().props["media.name"];
         if (code == target ||
-            (target == "-1" && !isExcluded(name)))
+            (target == "-1" && !isExcluded(media_name)))
             {
                 std::cout << "Link   : " << target << ":" << port_id << " -> ";
 

--- a/native/pipewire-screenaudio/main.cpp
+++ b/native/pipewire-screenaudio/main.cpp
@@ -9,6 +9,13 @@ std::optional<pipewire::port> virt_fl, virt_fr;
 std::map<std::uint32_t, pipewire::node> nodes;
 std::map<std::uint32_t, pipewire::link> links;
 
+std::vector<std::string> EXCLUDE_TARGETS{"Firefox"};
+
+bool isExcluded(const std::string &target) {
+  auto it = std::find(EXCLUDE_TARGETS.begin(), EXCLUDE_TARGETS.end(), target);
+  return it != EXCLUDE_TARGETS.end();
+}
+
 void link(const std::string &target, pipewire::core &core)
 {
     for (const auto &[port_id, port] : ports)
@@ -32,9 +39,18 @@ void link(const std::string &target, pipewire::core &core)
 
         auto &parent = nodes.at(parent_id);
 
-        if (parent.info().props["object.serial"].find(target) != std::string::npos)
-        {
-            std::cout << "Link   : " << target << ":" << port_id << " -> ";
+        if (!parent.info().props.count("media.class") ||
+            parent.info().props["media.class"] != "Stream/Output/Audio")
+            {
+          continue;
+        }
+
+        auto code = parent.info().props["object.serial"];
+        auto name = parent.info().props["node.name"];
+        if (code == target ||
+            (target == "-1" && !isExcluded(name)))
+            {
+                std::cout << "Link   : " << target << ":" << port_id << " -> ";
 
             if (port.info().props["audio.channel"] == "FL")
             {


### PR DESCRIPTION
I implemented the All Desktop Audio feature looking at how [discord-screenaudio](https://github.com/maltejur/discord-screenaudio) does it, but it has a few problems.

I connect all nodes except "Firefox" to the virtual sink so that it doesn't send the call audio through stream audio. The problem with this is your other firefox tabs audio won't be sent. discord-screenaudio can fix this because they can choose the node name and then exclude it.

It's a bit scuffed because I didn't change any code from the extension, but this might help as a start.

Thanks for this project!