### PR TITLE
Implement switching nodes while streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ bash install.sh
 - Stream, your transmission should contain both audio and video
  
 ## Known Problems
-- There is no way to change the audio node you're sharing while streaming
 - You can't stream firefox WebRTC calls at all while using `All Desktop Audio`, they are excluded by default
 ### resistFingerprinting
 - privacy.resistFingerprinting (enabled by default in LibreWolf, arkenfox user.js, etc.) breaks the extension. Either disable the preference or add any domains you wish to use Pipewire Screenaudio with to `privacy.resistFingerprinting.exemptedDomains` in `about:config`
@@ -64,6 +63,5 @@ bash install.sh
 
 ## Planned Features
 - Multiple nodes selection
-- Change audio node while streaming
 - More customization options (node matching, watcher behavior etc.)
 - Chromium support

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Based on [link-app-to-mic](https://github.com/Soundux/rohrkabel/tree/master/exam
 - jq
 - pipewire
 - psmisc
-- socat
 
 ```bash
 git clone https://github.com/IceDBorn/pipewire-screenaudio.git

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Based on [link-app-to-mic](https://github.com/Soundux/rohrkabel/tree/master/exam
 - jq
 - pipewire
 - psmisc
+- socat
 
 ```bash
 git clone https://github.com/IceDBorn/pipewire-screenaudio.git

--- a/extension/assets/web/html/popup.html
+++ b/extension/assets/web/html/popup.html
@@ -25,7 +25,7 @@
   <div id="root" class="container-fluid text-center flex-grow-1 d-flex flex-column justify-content-center align-items-center">
     <div id="message"></div>
     <select id="dropdown" class="form-select text-truncate mb-2"></select>
-    <div id="btn-group" />
+    <div id="btn-group">
       <button id="share-stop-btn">
     </div>
   </div>

--- a/extension/assets/web/html/popup.html
+++ b/extension/assets/web/html/popup.html
@@ -26,6 +26,8 @@
     <div id="message"></div>
     <select id="dropdown" class="form-select text-truncate mb-2"></select>
     <div id="btn-group" />
+      <button id="share-stop-btn">
+    </div>
   </div>
 </body>
 <script src="../../../scripts/popup.js"></script>

--- a/extension/assets/web/html/popup.html
+++ b/extension/assets/web/html/popup.html
@@ -11,7 +11,7 @@
 
 </head>
 
-<body data-bs-theme="dark" style="max-width: 19rem; width: 19rem; max-height: 11rem; height: 11rem;">
+<body data-bs-theme="dark" class="d-flex flex-column" style="max-width: 19rem; width: 19rem; max-height: 11rem; height: 11rem;">
   <!-- Navbar -->
   <nav class="navbar bg-body-tertiary">
     <div class="container-fluid">
@@ -22,9 +22,9 @@
     </div>
   </nav>
   <!-- Content -->
-  <div id="root" class="container-fluid text-center px-4 mt-4">
-    <div id="message" class="mt-4 mb-3"></div>
-    <select id="dropdown" class="form-select text-truncate mb-3"></select>
+  <div id="root" class="container-fluid text-center flex-grow-1 d-flex flex-column justify-content-center align-items-center">
+    <div id="message"></div>
+    <select id="dropdown" class="form-select text-truncate mb-2"></select>
     <div id="btn-group" />
   </div>
 </body>

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -1,14 +1,21 @@
 function handleMessage (response) {
-  if (response.message === 'node-shared') {
-    // Passthrough the selected node to pipewire-screenaudio
-    chrome.runtime.sendNativeMessage(response.messageName, { cmd: response.cmd, args: response.args })
+  if (response.message === 'sharing-started') {
+    // Start pipewire-screenaudio
+    chrome.runtime.sendNativeMessage(response.messageName, { cmd: response.cmd })
       .then(({ micId }) => {
         window.localStorage.setItem('micId', micId)
         chrome.runtime.sendMessage('mic-id-updated')
+        // Passthrough the selected node to pipewire-screenaudio
+        chrome.runtime.sendNativeMessage(response.messageName, {cmd: 'SetSharingNode', args: response.args })
       })
   }
 
-  if (response.message === 'node-stopped') {
+  if (response.message === 'node-changed') {
+    // Passthrough the selected node to pipewire-screenaudio
+    chrome.runtime.sendNativeMessage(response.messageName, { cmd: response.cmd, args: response.args })
+  }
+
+  if (response.message === 'sharing-stopped') {
     chrome.runtime.sendNativeMessage(response.messageName, { cmd: response.cmd, args: response.args })
       .then(() => {
         window.localStorage.setItem('micId', null)

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -1,4 +1,4 @@
-function handleMessage (response) {
+function handleMessage(response) {
   if (response.message === 'sharing-started') {
     // Start pipewire-screenaudio
     chrome.runtime.sendNativeMessage(response.messageName, { cmd: response.cmd })
@@ -6,7 +6,7 @@ function handleMessage (response) {
         window.localStorage.setItem('micId', micId)
         chrome.runtime.sendMessage('mic-id-updated')
         // Passthrough the selected node to pipewire-screenaudio
-        chrome.runtime.sendNativeMessage(response.messageName, {cmd: 'SetSharingNode', args: response.args })
+        chrome.runtime.sendNativeMessage(response.messageName, { cmd: 'SetSharingNode', args: [{ node: response.args[0].node, micId }] })
       })
   }
 

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -122,6 +122,15 @@ async function populateNodesList (response) {
       whitelistedNodes = response.filter(node => !bnNames.includes(node.properties['application.name']))
     }
 
+    // If last selected node doesn't exist in whitelistedNodes, ignore it
+    if (
+      !whitelistedNodes
+        .map(element => element.properties['object.serial'])
+        .includes(parseInt(window.localStorage.getItem('selectedNode')))
+    ) {
+      window.localStorage.setItem('selectedNode', null);
+    }
+
     for (const element of whitelistedNodes) {
       let text = element.properties['media.name']
       if (element.properties['application.name']) {
@@ -182,7 +191,6 @@ function onResponse (response) {
   chrome.runtime.sendNativeMessage(MESSAGE_NAME, { cmd: 'GetNodes', args: [] }).then(onReload, onError)
   nodesLoop = setInterval(() => { chrome.runtime.sendNativeMessage(MESSAGE_NAME, { cmd: 'GetNodes', args: [] }).then(onReload, onError) }, 1000)
   window.localStorage.setItem('nodesList', null)
-  window.localStorage.setItem('selectedNode', null)
   updateGui()
 }
 

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -44,8 +44,8 @@ function createShareBtn (root) {
     shareBtnEl.appendChild(text)
     document.getElementById('blacklist-btn').hidden = true
 
-    chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'node-shared', cmd: 'StartPipewireScreenAudio', args: [{ node: selectedNode }] })
-  } 
+    chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'sharing-started', cmd: 'StartPipewireScreenAudio', args: [{ node: selectedNode }] })
+  }
 
   shareBtnEl.addEventListener('click', eventListener)
 }
@@ -62,7 +62,7 @@ function createStopBtn (root) {
   stopBtnEl.addEventListener('click', async () => {
     if (await isRunning()) {
       const micId = window.localStorage.getItem('micId')
-      chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'node-stopped', cmd: 'StopPipewireScreenAudio', args: [{ micId }] })
+      chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'sharing-stopped', cmd: 'StopPipewireScreenAudio', args: [{ micId }] })
     }
   })
 }
@@ -96,7 +96,7 @@ async function updateGui () {
   if (await isRunning()) {
     message.innerText = `Running virtmic Id: ${window.localStorage.getItem('micId')}`
     message.hidden = false
-    dropdown.hidden = true
+    dropdown.hidden = false
     createStopBtn(buttonGroup)
   } else if (dropdown.children.length) {
     message.hidden = true
@@ -154,6 +154,7 @@ async function populateNodesList (response) {
     dropdown.addEventListener('change', () => {
       selectedNode = dropdown.value
       window.localStorage.setItem('selectedNode', selectedNode)
+      chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'node-changed', cmd: 'SetSharingNode', args: [{ node: selectedNode }] })
     })
   }
 }
@@ -169,12 +170,12 @@ function onReload (response) {
   updateGui()
 }
 
-function onResponse (response) {  
+function onResponse (response) {
   if (!checkVersionMatch(response.version)) {
     message.innerText = `Version mismatch\nExtension: ${EXT_VERSION}\nNative: ${response.version}`
     dropdown.hidden = true
     return
-  } 
+  }
   const settings = document.getElementById('settings')
   settings.addEventListener('click', async () => {
     window.open('settings.html')

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -54,7 +54,7 @@ function createStopBtn (root) {
   if (document.getElementById('stop-btn')) return
   const stopBtn = document.createElement('button')
   stopBtn.id = 'stop-btn'
-  stopBtn.className = 'btn btn-danger mt-3'
+  stopBtn.className = 'btn btn-danger'
   stopBtn.innerText = 'Stop'
   root.appendChild(stopBtn)
 
@@ -105,7 +105,6 @@ async function updateGui () {
     createBlacklistBtn(buttonGroup)
   } else {
     message.innerText = 'No nodes available to share...'
-    message.className = 'mt-5'
     message.hidden = false
     dropdown.hidden = true
   }

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -73,7 +73,7 @@ function createBlacklistBtn (root) {
 
   blacklistBtn.addEventListener('click', async () => {
     const nodesList = JSON.parse(window.localStorage.getItem('nodesList'))
-    const nodeToBlacklist = { name: nodesList.find(n => n.properties['object.serial'] === dropdown.value).properties['application.name'] }
+    const nodeToBlacklist = { name: nodesList.find(n => n.properties['object.serial'] === parseInt(dropdown.value)).properties['application.name'] }
     const blacklistedNodes = []
 
     const items = window.localStorage.getItem('blacklistedNodes')

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -154,7 +154,8 @@ async function populateNodesList (response) {
     dropdown.addEventListener('change', () => {
       selectedNode = dropdown.value
       window.localStorage.setItem('selectedNode', selectedNode)
-      chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'node-changed', cmd: 'SetSharingNode', args: [{ node: selectedNode }] })
+      const micId = window.localStorage.getItem('micId')
+      chrome.runtime.sendMessage({ messageName: MESSAGE_NAME, message: 'node-changed', cmd: 'SetSharingNode', args: [{ node: selectedNode, micId }] })
     })
   }
 }

--- a/extension/scripts/popup.js
+++ b/extension/scripts/popup.js
@@ -5,6 +5,7 @@ const dropdown = document.getElementById('dropdown')
 const message = document.getElementById('message')
 const buttonGroup = document.getElementById('btn-group')
 const shareStopBtn = document.getElementById('share-stop-btn')
+let shareStopBtnState = null
 
 let selectedNode = null
 let nodesLoop = null
@@ -25,11 +26,13 @@ async function isRunning () {
 }
 
 function setButtonToShare() {
+  shareStopBtnState = "share"
   shareStopBtn.className = 'btn btn-success me-2'
   shareStopBtn.innerText = 'Share'
 
   const eventListener = () => {
     shareStopBtn.removeEventListener('click', eventListener)
+    shareStopBtnState = "sharing"
     const spinner = document.createElement('span')
     const text = document.createElement('span')
     shareStopBtn.innerText = ''
@@ -48,6 +51,7 @@ function setButtonToShare() {
 
 
 function setButtonToStop() {
+  shareStopBtnState = "stop"
   shareStopBtn.className = 'btn btn-danger'
   shareStopBtn.innerText = 'Stop'
 
@@ -94,12 +98,14 @@ async function updateGui () {
     message.hidden = false
     dropdown.hidden = false
     shareStopBtn.hidden = false
-    setButtonToStop()
+    if (shareStopBtnState !== "stop")
+      setButtonToStop()
   } else if (dropdown.children.length) {
     message.hidden = true
     dropdown.hidden = false
     shareStopBtn.hidden = false
-    setButtonToShare()
+    if (shareStopBtnState !== "share")
+      setButtonToShare()
     createBlacklistBtn(buttonGroup)
   } else {
     message.innerText = 'No nodes available to share...'

--- a/native/connector/connect-and-monitor.sh
+++ b/native/connector/connect-and-monitor.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# This script finds and connects targetNodeSerial to virtual mic
+
+virtmicPortFlId=$1
+virtmicPortFrId=$2
+targetNodeSerial=$3
+
+
+EXCLUDED_TARGETS='"AudioCallbackDriver"'
+
+fullDumpFile=`mktemp`
+streamsFile=`mktemp`
+portsFile=`mktemp`
+
+
+function monitor-nodes() {
+    tail -f /dev/null | pw-cli -m | grep --line-buffered -v 'pipewire.sec.label = "hex:'
+}
+
+set -e
+
+# Cleanup on exit
+trap "rm $fullDumpFile $streamsFile $portsFile; trap - SIGTERM && kill -- -$$" SIGTERM EXIT
+
+pw-dump | jq -s "flatten(1)" > $fullDumpFile
+# Get streams from $fullDumpFile
+cat "$fullDumpFile" | jq -c '[ .[] | select(.info.props["media.class"] == "Stream/Output/Audio") ]' > $streamsFile
+
+# Get output ports of streams from $fullDumpFile
+streamIds=`cat "$streamsFile" | jq -c '.[].id' | paste -sd ','`
+cat "$fullDumpFile" | jq -c "[ .[] | select(.type == \"PipeWire:Interface:Port\") | select(.info.direction == \"output\") | select(.info.props[\"node.id\"] | contains($streamIds)) ]" > $portsFile
+if [[ ! "$targetNodeSerial" -eq "-1" ]]; then
+    # Get target node id from $streamsFile
+    targetNodeId=`cat "$streamsFile" | jq -c "[ .[] | select(.info.props[\"object.serial\"] == $targetNodeSerial) ][0].id"`
+
+    # Get target node ports ids from $portsFile
+    targetPortsFile=`mktemp`
+    cat "$portsFile" | jq -c "[ .[] | select(.info.props[\"node.id\"] == $targetNodeId) ]" > $targetPortsFile
+    targetPortFlId=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FL\") ][0].id"`
+    targetPortFrId=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FR\") ][0].id"`
+    rm $targetPortsFile
+
+    # Connect target to virtmic
+    pw-link $targetPortFlId $virtmicPortFlId
+    pw-link $targetPortFrId $virtmicPortFrId
+else
+    # Get target nodes ids to connect from $streamsFile
+    targetNodesIds=`cat $streamsFile | jq -c "[ .[] | select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not) ][].id" | paste -sd ','`
+
+    if [[ ! "$targetNodesIds" -eq "" ]]; then
+        # Get target nodes ports ids from $portsFile
+        targetPortsFile=`mktemp`
+        cat "$portsFile" | jq -c "[ .[] | select(.info.props[\"node.id\"] | contains($targetNodesIds)) ]" > $targetPortsFile
+        targetPortsFlIds=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FL\") ][].id"`
+        targetPortsFrIds=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FR\") ][].id"`
+        rm $targetPortsFile
+
+        # Connect targets to virtmic
+        echo "$targetPortsFlIds" | while read -r id; do pw-link $id $virtmicPortFlId; done
+        echo "$targetPortsFrIds" | while read -r id; do pw-link $id $virtmicPortFrId; done
+    fi
+
+    # Watch for new nodes to connect
+    monitor-nodes | {
+        stdbuf -o0 awk '/remote 0 added global/ && /Node/' |
+            grep --line-buffered -oP 'id \K\d+' |
+            while read -r id; do (
+                # Skip excluded targets
+                pw-dump "$id" | jq --exit-status -c "
+                    [
+                        .[] |
+                        select(.id == $id) |
+                        select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not)
+                    ][0].id
+                " >/dev/null || exit
+
+                # 1. Find the ports with node.id == $id
+                # 2. Get only the FR and FL ports
+                # 3. Sort by audio.channel (FR > FL)
+                # 4. Return only the ids
+                ids=`pw-dump | jq -s -c "
+                    flatten(1) |
+                    [
+                        .[] |
+                        select(.info.props[\"node.id\"] == $id) |
+                        select(.info.props[\"audio.channel\"] | contains(\"FR\", \"FL\"))
+                    ] |
+                    sort_by(.info.props[\"audio.channel\"]) |
+                    .[].id
+                " | xargs` # Merge to one line
+
+                # As channels were sorted, $1 is FR and $2 is FL
+                flId=`echo "$ids" | awk '{print $1}'`
+                frId=`echo "$ids" | awk '{print $2}'`
+
+                # Connect new node to virtmic
+                pw-link $flId $virtmicPortFlId
+                pw-link $frId $virtmicPortFrId
+            ) done
+    } &
+fi
+
+wait

--- a/native/connector/pipewire-screen-audio-connector.sh
+++ b/native/connector/pipewire-screen-audio-connector.sh
@@ -66,12 +66,12 @@ function SetSharingNode () {
   local args="$1"
 
   local node=`echo $args | jq -r '.[].node' | head -n 1`
+  local virtmicId=`echo $args | jq -r '.[].micId' | head -n 1`
+  fifoPath="$XDG_RUNTIME_DIR/pipewire-screenaudio-set-node-$virtmicId"
 
-  # Get tmp directory path
-  tmpdir=$(dirname $(mktemp -u))
-  idSockFile=$tmpdir/pipewire-screenaudio.sock
-  echo "$node" |
-    socat stdin unix-client:$idSockFile
+  if [ -e "$fifoPath" ]; then
+    echo "$node" >> "$fifoPath"
+  fi
 
   exit
 }

--- a/native/connector/virtmic.sh
+++ b/native/connector/virtmic.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
-targetNodeSerial="$1"
 virtmicNode='pipewire-screenaudio'
 
 myPid=$$
-
-EXCLUDED_TARGETS='"AudioCallbackDriver"'
 
 set -e
 
 # Get all nodes to check if $virtmicNode exists, and create it
 pw-dump |
-    jq --exit-status -c "[ .[] | select(.info.props[\"node.name\"] == \"$virtmicNode\") ][0]" >/dev/null ||
+    jq --exit-status -c -s "flatten(1) | [ .[] | select(.info.props[\"node.name\"] == \"$virtmicNode\") ][0]" >/dev/null ||
     pw-cli create-node adapter "{ factory.name=support.null-audio-sink node.name=$virtmicNode media.class=Audio/Source/Virtual object.linger=1 audio.position=[FL,FR] }"
 
-# === Collect required data from PipeWire === #
-
-# Get all nodes again for further processing
 fullDumpFile=`mktemp`
-pw-dump > $fullDumpFile
+
+# Cleanup on exit
+trap "rm $fullDumpFile; kill -- -$myPid" EXIT
+
+# === Collect required data from PipeWire === #
+# Get all nodes again for further processing
+pw-dump | jq -s "flatten(1)" > $fullDumpFile
 
 # Get id and ports of $virtmicNode
 virtmicId=`cat "$fullDumpFile" | jq -c "[ .[] | select(.info.props[\"node.name\"] == \"$virtmicNode\") ][0].id"`
@@ -28,95 +28,55 @@ virtmicPortFlId=`cat "$virtmicPortsFile" | jq -c "[ .[] | select(.info.props[\"a
 virtmicPortFrId=`cat "$virtmicPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FR\") ][0].id"`
 rm $virtmicPortsFile
 
-# Get streams from $fullDumpFile
-streamsFile=`mktemp`
-cat "$fullDumpFile" | jq -c '[ .[] | select(.info.props["media.class"] == "Stream/Output/Audio") ]' > $streamsFile
+function monitor-nodes() {
+    tail -f /dev/null | pw-cli -m | grep --line-buffered -v 'pipewire.sec.label = "hex:'
+}
 
-# Get output ports of streams from $fullDumpFile
-portsFile=`mktemp`
-streamIds=`cat "$streamsFile" | jq -c '.[].id' | paste -sd ','`
-cat "$fullDumpFile" | jq -c "[ .[] | select(.type == \"PipeWire:Interface:Port\") | select(.info.direction == \"output\") | select(.info.props[\"node.id\"] | contains($streamIds)) ]" > $portsFile
+function disconnectInputs() {
+    node=$1
+    pw-dump | jq -s -r "
+        flatten(1) |
+        [
+            .[] |
+            select(.info[\"input-node-id\"] == $node) |
+            .id
+        ] |
+        .[]
+    " | xargs -r -n1 pw-cli destroy
+}
 
-# === Connect the target node(s) to $virtmicNode === #
+# Get tmp directory path
+tmpdir=$(dirname $(mktemp -u))
+idSockFile=$tmpdir/pipewire-screenaudio.sock
 
-if [[ ! "$targetNodeSerial" -eq "-1" ]]; then
-    # Get target node id from $streamsFile
-    targetNodeId=`cat "$streamsFile" | jq -c "[ .[] | select(.info.props[\"object.serial\"] == $targetNodeSerial) ][0].id"`
+# Listen to selected node change
+socat unix-listen:$idSockFile,fork,unlink-early stdout | {
+    # Kill connect-and-monitor.sh process if it's still alive
+    function killMonitor() {
+        if [ ! -z "$monitorProcess" ]; then
+            kill $monitorProcess || :
+        fi
+    }
 
-    # Get target node ports ids from $portsFile
-    targetPortsFile=`mktemp`
-    cat "$portsFile" | jq -c "[ .[] | select(.info.props[\"node.id\"] == $targetNodeId) ]" > $targetPortsFile
-    targetPortFlId=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FL\") ][0].id"`
-    targetPortFrId=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FR\") ][0].id"`
-    rm $targetPortsFile
+    # Kill monitor process when this background process gets killed
+    trap "killMonitor" EXIT
 
-    # Connect target to virtmic
-    pw-link $targetPortFlId $virtmicPortFlId
-    pw-link $targetPortFrId $virtmicPortFrId
-else
-    # Get target nodes ids to connect from $streamsFile
-    targetNodesIds=`cat $streamsFile | jq -c "[ .[] | select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not) ][].id" | paste -sd ','`
+    # Read the new target node
+    while read -r targetNodeSerial; do
+        killMonitor
+        disconnectInputs "$virtmicId"
+        setsid bash -- connect-and-monitor.sh "$virtmicPortFlId" "$virtmicPortFrId" "$targetNodeSerial" &
+        monitorProcess=$!
+    done
+} &
 
-    if [[ ! "$targetNodesIds" -eq "" ]]; then
-        # Get target nodes ports ids from $portsFile
-        targetPortsFile=`mktemp`
-        cat "$portsFile" | jq -c "[ .[] | select(.info.props[\"node.id\"] | contains($targetNodesIds)) ]" > $targetPortsFile
-        targetPortsFlIds=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FL\") ][].id"`
-        targetPortsFrIds=`cat "$targetPortsFile" | jq -c "[ .[] | select(.info.props[\"audio.channel\"] == \"FR\") ][].id"`
-        rm $targetPortsFile
+# Send SIGTERM to this process when the virtmic gets removed
+monitor-nodes |
+    stdbuf -o0 awk '/remote 0 removed global/ && /Node/' |
+    grep --line-buffered -oP "id \\K$virtmicId" | {
+    while read -r id; do
+        kill -SIGTERM $myPid
+    done
+} &
 
-        # Connect targets to virtmic
-        echo "$targetPortsFlIds" | while read -r id; do pw-link $id $virtmicPortFlId; done
-        echo "$targetPortsFrIds" | while read -r id; do pw-link $id $virtmicPortFrId; done
-    fi
-
-    # Watch for new nodes to connect
-    tail -f /dev/null | pw-cli -m | grep --line-buffered -v 'pipewire.sec.label = "hex:' | tee >(
-        stdbuf -o0 awk '/remote 0 added global/ && /Node/' |
-            grep --line-buffered -oP 'id \K\d+' |
-            while read -r id; do (
-                # Skip excluded targets
-                pw-dump "$id" | jq --exit-status -c "
-                    [
-                        .[] |
-                        select(.id == $id) |
-                        select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not)
-                    ][0].id
-                " >/dev/null || exit
-
-                # 1. Find the ports with node.id == $id
-                # 2. Get only the FR and FL ports
-                # 3. Sort by audio.channel (FR > FL)
-                # 4. Return only the ids
-                ids=`pw-dump | jq -c "
-                    [
-                        .[] |
-                        select(.info.props[\"node.id\"] == $id) |
-                        select(.info.props[\"audio.channel\"] | contains(\"FR\", \"FL\"))
-                    ] |
-                    sort_by(.info.props[\"audio.channel\"]) |
-                    .[].id
-                " | xargs` # Merge to one line
-
-                # As channels were sorted, $1 is FR and $2 is FL
-                flId=`echo "$ids" | awk '{print $1}'`
-                frId=`echo "$ids" | awk '{print $2}'`
-
-                # Connect new node to virtmic
-                pw-link $flId $virtmicPortFlId
-                pw-link $frId $virtmicPortFrId
-            ) & done
-    ) \
-    >(
-        stdbuf -o0 awk '/remote 0 removed global/ && /Node/' |
-            grep --line-buffered -oP "id \\K$virtmicId" |
-            while read -r id; do
-                pstree -A -p $myPid | grep -Eow '[0-9]+' | xargs kill -2
-            done
-    )
-fi
-
-# Cleanup
-rm $fullDumpFile
-rm $streamsFile
-rm $portsFile
+wait


### PR DESCRIPTION
I split the “node-shared” message into “sharing-started” and “node-changed” messages, so that you can start the program once and then you can change the node while it runs.

I used Unix socks to notify the script each time the selected node changes.

Each time the selected node changes I kill the process that connects new nodes and destroy all the links connected to the virtual node, then I run the script that connects new nodes again with the new target node.

I had to move the connection code to a separate script to be able to cleanup after it is killed.

I noticed `pw-dump` sometimes outputs multiple objects instead of one, causing `jq` to produce wrong output. That's why I added `flatten(1)` and `-s` to every jq that parses pw-dump.

<details>
  <summary>How to replicate pw-dump giving extra output</summary>

Leave this running in a terminal:
```sh
while true; do
    pw-dump > /dev/null
done
```
and at the same time run `pw-dump` on another terminal.
The output you'll get is something like:
```
[
  {
    // Expected output
  }
]
[
  {
    "id": 100,
    "info": null
  }
]
[
  {
    "id": 100,
    "info": null
  }
]
[
  {
    "id": 100,
    "info": null
  }
]
```
</details>