### PR TITLE
Fix monitor process exiting sometimes

### DIFF
--- a/native/connector/connect-and-monitor.sh
+++ b/native/connector/connect-and-monitor.sh
@@ -73,7 +73,7 @@ else
                         select(.id == $id) |
                         select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not)
                     ][0].id
-                " >/dev/null || exit
+                " >/dev/null || exit 0
 
                 # 1. Find the ports with node.id == $id
                 # 2. Get only the FR and FL ports

--- a/native/connector/connect-and-monitor.sh
+++ b/native/connector/connect-and-monitor.sh
@@ -66,12 +66,13 @@ else
         stdbuf -o0 awk '/remote 0 added global/ && /Node/' |
             grep --line-buffered -oP 'id \K\d+' |
             while read -r id; do (
-                # Skip excluded targets
+                # Skip excluded targets and targets with wrong class
                 pw-dump "$id" | jq --exit-status -c "
                     [
                         .[] |
                         select(.id == $id) |
-                        select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not)
+                        select(.info.props[\"media.name\"] | contains($EXCLUDED_TARGETS) | not) |
+                        select(.info.props[\"media.class\"] == \"Stream/Output/Audio\" )
                     ][0].id
                 " >/dev/null || exit 0
 


### PR DESCRIPTION
@IceDBorn and I noticed that the monitor process sometimes stops connecting new nodes.
I investigated the cause and found two problems:
1. The process exited when the "AudioCallbackDriver" node gets created at runtime, that's because the `exit` bash command apparently forwards the status code from `jq`, so the whole bash process exits because of `set -e`. By using `exit 0` explicitly, this gets fixed.
2. The monitor process doesn't check that `media.class` is "Stream/Output/Audio" whenever a new node appears. I noticed this when I ran [easyeffects](https://github.com/wwmm/easyeffects) (program for processing microphone input) and the monitor process tried to connect the filter nodes to `pipewire-screenaudio` node, even though they are not Output nodes (this also caused the monitor process to exit).