### PR TITLE
Workaround for removing duplicated audio

### DIFF
--- a/extension/scripts/index.js
+++ b/extension/scripts/index.js
@@ -47,6 +47,9 @@ function overrideGdm () {
       }
     })
     const [track] = captureSystemAudioStream.getAudioTracks()
+    const fakegdm = await navigator.mediaDevices.chromiumGetDisplayMedia({
+      video: true
+    })
     const gdm = await navigator.mediaDevices.chromiumGetDisplayMedia({
       video: true,
       audio: true


### PR DESCRIPTION
I observed that when one tab is already capturing the desktop, and another tab tries to request display permission using `getDisplayMedia()`, the popup from xdg-desktop-portal does not appear. Instead, it automatically selects the same desktop capture source that the first tab was using.
So I made a `getDisplayMedia()` call to make the popup show, and then another call to then return the second one, so whatever discord is doing to that object doesn't create more popups. Now it won't show the popup multiple times and the audio doesn't get duplicated.

Sadly, this worsens the experience on other WebRTC sites, as it requests twice for permission. I didn't try this on X11, so it might be even worse.

#16