### PR TITLE
Fix transient activation issue on workaround

### DIFF
--- a/extension/scripts/index.js
+++ b/extension/scripts/index.js
@@ -51,7 +51,7 @@ function overrideGdm () {
     const [track] = captureSystemAudioStream.getAudioTracks()
     let fakegdm;
     if (new RegExp('^(.+\.)?discord.com$').test(window.location.host) && sessionType === "wayland") {
-      fakegdm = await navigator.mediaDevices.chromiumGetDisplayMedia({
+      fakegdm = navigator.mediaDevices.chromiumGetDisplayMedia({
         video: true
       })
     }


### PR DESCRIPTION
I removed the await to the first getDisplayMedia to make the two getDisplayMedia get called at the start, this makes firefox allow it even if you take more than 5 seconds choosing.