### PR TITLE
Background.js full rework

### DIFF
--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -22,7 +22,7 @@ async function runQueuedCommands () {
     }
 
     console.log(args)
-    const result = await sendNativeMessage(command.messageName, command.cmd, command.args, command.maps)
+    const result = await sendNativeMessage(command.messageName, command.cmd, args, command.maps)
     console.log(result)
 
     if (outMap) {

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -1,35 +1,56 @@
 // Any event, that is handled in here, should have a comment with the reason it is handled in here
 
-function handleMessage(request) {
-  // Asynchronously update micId in LocalStorage
-  if (request.message === "sharing-started") {
-    chrome.runtime
-      .sendNativeMessage(request.messageName, { cmd: request.cmd })
-      .then(({ micId }) => {
-        window.localStorage.setItem("micId", micId);
-        chrome.runtime.sendMessage("mic-id-updated");
+let commandsQueue = []
+let commandsQueueRunning = false
+
+function sendNativeMessage (messageName, cmd, args) {
+  return chrome.runtime.sendNativeMessage(messageName, { cmd, args: (args ? [args] : undefined) })
+}
+
+async function runQueuedCommands () {
+  commandsQueueRunning = true;
+
+  while (commandsQueue.length) {
+    const command = commandsQueue.shift();
+    const args = { ...command.args };
+    const { inMap, outMap } = command.maps || {};
+
+    if (inMap) {
+      inMap.forEach(([storageKey, argKey]) => {
+        args[argKey] = window.localStorage.getItem(storageKey);
       });
+    }
+
+    console.log(args)
+    const result = await sendNativeMessage(command.messageName, command.cmd, command.args, command.maps)
+    console.log(result)
+
+    if (outMap) {
+      outMap.forEach(([storageKey, resultKey]) => {
+        window.localStorage.setItem(storageKey, (resultKey ? result[resultKey] : null));
+      });
+    }
+
+    if (command.event) {
+      chrome.runtime.sendMessage(command.event);
+    }
   }
 
-  // Asynchronously update micId in LocalStorage
-  if (request.message === "sharing-stopped") {
-    chrome.runtime
-      .sendNativeMessage(request.messageName, {
-        cmd: request.cmd,
-        args: request.args,
-      })
-      .then(() => {
-        window.localStorage.setItem("micId", null);
-        chrome.runtime.sendMessage("mic-id-removed");
-      });
+  commandsQueueRunning = false;
+}
+
+function handleMessage(request) {
+  // Run multiple commands sequentially
+  if (request.message === "enqueue-command") {
+    commandsQueue.push({ ...request.command, messageName: request.messageName })
+    if (!commandsQueueRunning) {
+      runQueuedCommands();
+    }
   }
 
   // Called from injector.js - It cannot directly call sendNativeMessage
   if (request.message === "get-session-type") {
-    return chrome.runtime.sendNativeMessage(request.messageName, {
-      cmd: "GetSessionType",
-      args: [],
-    });
+    return sendNativeMessage(request.messageName, "GetSessionType");
   }
 }
 


### PR DESCRIPTION
Closes #47 

Introduces the `enqueue-command` message in `background.js`, which accepts a `command`, with the following fields:
- `cmd`: the `cmd` that will be passed to native
- `args`: the `args` that will be passed to native
- `maps.inMap`: an array of string pairs
	- first string in pair: the key of the LocalStorage entry to read
	- second string in pair: the field to set in `args`
- `maps.outMap`: an array of string pairs
 	- first string in pair: the key of the LocalStorage entry to set
	- second string in pair: the field in the response from native to read (can be null, to clear the LocalStorage)
- `event`: a message to send after the completion of the command