### PR TITLE
Fix undefined exception on GetSessionType

### DIFF
--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -66,7 +66,7 @@ function handleMessage(request) {
 
     // Called from injector.js - It cannot directly call sendNativeMessage
     case "get-session-type":
-      sendNativeMessage(request.messageName, "GetSessionType");
+      return sendNativeMessage(request.messageName, "GetSessionType");
       break;
 
     default:


### PR DESCRIPTION
Browser throws `TypeError: (destructured parameter) is undefined` on this line
https://github.com/IceDBorn/pipewire-screenaudio/blob/452fc601615069cc0de6e4868839e74d9d359b3f/extension/scripts/injector.js#L16