### PR TITLE
[RFC] Add chrome(ium) support to extension

### DIFF
--- a/extension/manifest-chrome.json
+++ b/extension/manifest-chrome.json
@@ -1,0 +1,44 @@
+{
+
+  "manifest_version": 3,
+  "name": "Pipewire Screenaudio",
+  "version": "0.3.4",
+
+  "description": "Passthrough pipewire audio to WebRTC screenshare",
+
+  "action": {
+    "default_popup": "assets/web/html/popup.html"
+  },
+
+  "icons": {
+    "16": "assets/icons/icon.svg",
+    "32": "assets/icons/icon.svg",
+    "48": "assets/icons/icon.svg",
+    "64": "assets/icons/icon.svg"
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "run_at": "document_start",
+      "js": ["scripts/injector.js"],
+      "all_frames": true
+    }
+  ],
+
+  "background": {
+    "service_worker": "scripts/background.js"
+  },
+
+  "permissions": [
+    "nativeMessaging"
+  ],
+
+  "web_accessible_resources": [
+    {
+      "matches": ["<all_urls>"],
+      "resources": [ "scripts/index.js" ]
+    }
+  ]
+
+}

--- a/extension/scripts/background.js
+++ b/extension/scripts/background.js
@@ -17,9 +17,9 @@ async function runQueuedCommands () {
       const { inMap, outMap } = command.maps || {};
 
       if (inMap) {
-        inMap.forEach(([storageKey, argKey]) => {
-          args[argKey] = window.localStorage.getItem(storageKey);
-        });
+        for (const [storageKey, argKey] of inMap) {
+          args[argKey] = await chrome.runtime.sendMessage({ messageName: "get-storage", storageKey: storageKey })
+        }
       }
 
       console.log(args)
@@ -27,9 +27,10 @@ async function runQueuedCommands () {
       console.log(result)
 
       if (outMap) {
-        outMap.forEach(([storageKey, resultKey]) => {
-          window.localStorage.setItem(storageKey, (resultKey ? result[resultKey] : null));
-        });
+        for (const [storageKey, resultKey] of outMap) {
+          const value = resultKey ? result[resultKey] : null
+          await chrome.runtime.sendMessage({ messageName: 'set-storage', storageKey: storageKey, value: value })
+        }
       }
 
       if (command.event) {

--- a/extension/scripts/index.js
+++ b/extension/scripts/index.js
@@ -50,7 +50,7 @@ function overrideGdm () {
     })
     const [track] = captureSystemAudioStream.getAudioTracks()
     let fakegdm;
-    if (new RegExp('^(.+\.)?discord.com$').test(window.location.host) && sessionType === "wayland") {
+    if (new RegExp('^(.+\.)?discord.com$').test(window.location.host) && sessionType === "wayland" && typeof browser != 'undefined') {
       fakegdm = navigator.mediaDevices.chromiumGetDisplayMedia({
         video: true
       })

--- a/extension/scripts/injector.js
+++ b/extension/scripts/injector.js
@@ -11,7 +11,7 @@ function injectCode (src) {
   script.onload = function () {
     console.log('pipewire-screenaudio script injected')
 
-    browser.runtime
+    chrome.runtime
       .sendMessage({ messageName: MESSAGE_NAME, message: 'get-session-type' })
       .then(({ type }) => {
         window.postMessage({ message: "set-session-type", type })


### PR DESCRIPTION
This will add support for Chromium based browsers to the extension.

I have tested this on Firefox 124.0.1 and Chromium 123.0.6312.86.

While testing i encountered a Chromium (bug?) behavior that crashed the extension if chrome.runtime.sendNativeMessage was not awaited. This works fine on Firefox so i added the workaround that makes the popup menu take a second to load on Chromium. This shouldn't be a big deal.

The only needed change to package for chromium is to replace the manifest.json with the manifest-chrome.json and adjust the native extension once you get a release id on the chrome store.

Anyway, this is just for your consideration. Thanks for your work.