### PR TITLE
Remove obsolete discord audio duplication workaround

### DIFF
--- a/extension/scripts/index.js
+++ b/extension/scripts/index.js
@@ -49,12 +49,6 @@ function overrideGdm () {
       }
     })
     const [track] = captureSystemAudioStream.getAudioTracks()
-    let fakegdm;
-    if (new RegExp('^(.+\.)?discord.com$').test(window.location.host) && sessionType === "wayland") {
-      fakegdm = navigator.mediaDevices.chromiumGetDisplayMedia({
-        video: true
-      })
-    }
     const gdm = await navigator.mediaDevices.chromiumGetDisplayMedia({
       video: true,
       audio: true


### PR DESCRIPTION
Discord on Firefox used to show the screen capture popup multiple times, and that used to cause audio problems. This workaround makes the popup show two times, but in a way it didn't affect the audio. Now discord doesn't do that anymore, so this workaround is obsolete and just makes users do one more click.