### PR TITLE
feat: Add non-flake support with Lix flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+(import (
+  let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url = lock.nodes.${nodeName}.locked.url or "https://git.lix.systems/lix-project/flake-compat/archive/main.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,19 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777699697,
+        "narHash": "sha256-Eg9b/rq/ECYwNwEXs5i9wHyhxNI0JrYx2srdI2uZMaQ=",
+        "rev": "382052b74656a369c5408822af3f2501e9b1af81",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/flake-compat/archive/382052b74656a369c5408822af3f2501e9b1af81.tar.gz?rev=382052b74656a369c5408822af3f2501e9b1af81"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/flake-compat/archive/main.tar.gz"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1772773019,
@@ -18,6 +32,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,9 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-compat = {
+    url = "git+https://git.lix.systems/lix-project/flake-compat?ref=main";
+    flake = false;
+  };
   description = "The native part of the Pipewire Screenaudio extension";
 
   outputs =

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+(import (
+  let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url = lock.nodes.${nodeName}.locked.url or "https://git.lix.systems/lix-project/flake-compat/archive/master.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
- Add Lix flake-compat input to flake.nix
- Create default.nix for `nix-build default.nix` support
- Create shell.nix for `nix-shell` support

Allows users without flakes to build the package while maintaining full flake support for users who need it.